### PR TITLE
Override API in e2e tests to allow quick backend switch

### DIFF
--- a/.changelog/2089.internal.md
+++ b/.changelog/2089.internal.md
@@ -1,0 +1,1 @@
+Override API in e2e tests to allow quick backend switch

--- a/playwright/utils/mockApi.ts
+++ b/playwright/utils/mockApi.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../src/vendors/oasisscan/index'
 
 export async function mockApi(context: BrowserContext | Page, balance: number) {
+  await context.addInitScript(() => ((window as any).REACT_APP_BACKEND = 'oasisscan'))
   await context.route('**/chain/account/info/*', route => {
     route.fulfill({
       body: JSON.stringify({

--- a/src/app/components/Footer/__tests__/index.test.tsx
+++ b/src/app/components/Footer/__tests__/index.test.tsx
@@ -60,12 +60,6 @@ describe('<Footer />', () => {
     )
   })
 
-  it('should render backend label', () => {
-    renderComponent(store, 'large')
-
-    expect(screen.getByText(/Oasis Scan API/)).toBeInTheDocument()
-  })
-
   it('should render mobile version of footer', () => {
     renderComponent(store, 'small')
 

--- a/src/app/pages/AccountPage/__tests__/index.test.tsx
+++ b/src/app/pages/AccountPage/__tests__/index.test.tsx
@@ -90,7 +90,7 @@ describe('<AccountPage  />', () => {
       }),
     )
     const page = renderPage(store, ['/account/oasis1qz0k5q8vjqvu4s4nwxyj406ylnflkc4vrcjghuwk'])
-    expect(page.container).toHaveTextContent('Oasis Scan API appears to be down')
+    expect(page.container).toHaveTextContent(/API appears to be down/)
     const balance = await screen.findByTestId('account-balance-total')
     expect(balance).toHaveTextContent('-')
     const balanceSummary = await screen.findByTestId('account-balance-summary')

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,10 +1,20 @@
-declare namespace NodeJS {
-  export interface ProcessEnv {
-    REACT_APP_BACKEND: 'oasismonitor' | 'oasisscan' | 'oasisscanV2' | 'nexus'
-    REACT_APP_TRANSAK_URL: string
-    REACT_APP_TRANSAK_PARTNER_ID: string
-    REACT_APP_LOCALNET: '1' | undefined
-    REACT_APP_E2E_TEST: '1' | undefined
-    NODE_ENV: 'development' | 'production' | 'test'
+type Backend = 'oasismonitor' | 'oasisscan' | 'oasisscanV2' | 'nexus'
+
+declare global {
+  namespace NodeJS {
+    export interface ProcessEnv {
+      REACT_APP_BACKEND: Backend
+      REACT_APP_TRANSAK_URL: string
+      REACT_APP_TRANSAK_PARTNER_ID: string
+      REACT_APP_LOCALNET: '1' | undefined
+      REACT_APP_E2E_TEST: '1' | undefined
+      NODE_ENV: 'development' | 'production' | 'test'
+    }
+  }
+
+  interface Window {
+    REACT_APP_BACKEND: Backend
   }
 }
+
+export {}

--- a/src/vendors/backend.ts
+++ b/src/vendors/backend.ts
@@ -11,5 +11,8 @@ const backendNameToApi = {
   [BackendAPIs.Nexus]: getNexusAPIs,
 }
 
-export const backend = () => process.env.REACT_APP_BACKEND || BackendAPIs.OasisMonitor
+export const backend = () =>
+  (process.env.REACT_APP_E2E_TEST && window.REACT_APP_BACKEND) ||
+  process.env.REACT_APP_BACKEND ||
+  BackendAPIs.OasisMonitor
 export const backendApi = backendNameToApi[backend()]


### PR DESCRIPTION
Closes https://github.com/oasisprotocol/wallet/issues/2079

One snapshot will need to be updated when `REACT_APP_BACKEND` changes, but that is intentional
```
-           Oasis Scan API & Oasis gRPC
+           Nexus API & Oasis gRPC
```