### PR TITLE
Refactor how extension requests ledger access (don't rely on state sync)

### DIFF
--- a/.changelog/2094.bugfix.md
+++ b/.changelog/2094.bugfix.md
@@ -1,0 +1,1 @@
+Refactor how extension requests ledger access (don't rely on state sync)

--- a/extension/src/ExtLedgerAccessPopup/ExtLedgerAccessPopup.tsx
+++ b/extension/src/ExtLedgerAccessPopup/ExtLedgerAccessPopup.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useDispatch } from 'react-redux'
 import { Box } from 'grommet/es6/components/Box'
 import { Button } from 'grommet/es6/components/Button'
 import { Spinner } from 'grommet/es6/components/Spinner'
@@ -11,10 +10,9 @@ import { Header } from 'app/components/Header'
 import { ErrorFormatter } from 'app/components/ErrorFormatter'
 import { AlertBox } from 'app/components/AlertBox'
 import { WalletErrors } from 'types/errors'
-import { importAccountsActions } from 'app/state/importaccounts'
 import { requestDevice } from 'app/lib/ledger'
-import { WalletType } from '../../../src/app/state/wallet/types'
 import logotype from '../../../public/Icon Blue 192.png'
+import { MessageTypes } from '../../../src/utils/constants'
 
 type ConnectionStatus = 'connected' | 'disconnected' | 'connecting' | 'error'
 type ConnectionStatusIconPros = {
@@ -44,9 +42,10 @@ function ConnectionStatusIcon({ success = true, label, withMargin = false }: Con
   )
 }
 
+const chrome = (window as any).chrome
+
 export function ExtLedgerAccessPopup() {
   const { t } = useTranslation()
-  const dispatch = useDispatch()
   const [connection, setConnection] = useState<ConnectionStatus>('disconnected')
   const handleConnect = async () => {
     setConnection('connecting')
@@ -54,7 +53,7 @@ export function ExtLedgerAccessPopup() {
       const device = await requestDevice()
       if (device) {
         setConnection('connected')
-        dispatch(importAccountsActions.enumerateAccountsFromLedger(WalletType.UsbLedger))
+        chrome.runtime.sendMessage({ type: MessageTypes.USB_LEDGER_PERMISSION_GRANTED })
       }
     } catch {
       setConnection('error')

--- a/extension/src/ExtLedgerAccessPopup/ExtLedgerAccessPopup.tsx
+++ b/extension/src/ExtLedgerAccessPopup/ExtLedgerAccessPopup.tsx
@@ -53,7 +53,7 @@ export function ExtLedgerAccessPopup() {
       const device = await requestDevice()
       if (device) {
         setConnection('connected')
-        chrome.runtime.sendMessage({ type: MessageTypes.USB_LEDGER_PERMISSION_GRANTED })
+        chrome?.runtime?.sendMessage({ type: MessageTypes.USB_LEDGER_PERMISSION_GRANTED })
       }
     } catch {
       setConnection('error')

--- a/extension/src/ExtLedgerAccessPopup/__tests__/index.test.tsx
+++ b/extension/src/ExtLedgerAccessPopup/__tests__/index.test.tsx
@@ -1,10 +1,7 @@
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { requestDevice } from 'app/lib/ledger'
-import { importAccountsActions } from 'app/state/importaccounts'
 import { ExtLedgerAccessPopup } from '../ExtLedgerAccessPopup'
-import { WalletType } from '../../../../src/app/state/wallet/types'
 
 jest.mock('app/lib/ledger')
 
@@ -31,10 +28,6 @@ describe('<ExtLedgerAccessPopup />', () => {
     expect(await screen.findByText('ledger.extension.succeed')).toBeInTheDocument()
     expect(screen.getByLabelText('Status is okay')).toBeInTheDocument()
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
-    expect(mockDispatch).toHaveBeenCalledWith({
-      payload: WalletType.UsbLedger,
-      type: importAccountsActions.enumerateAccountsFromLedger.type,
-    })
   })
 
   it('should render error state', async () => {

--- a/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
@@ -9,10 +9,10 @@ import { useTranslation } from 'react-i18next'
 import { Capacitor } from '@capacitor/core'
 
 type SelectOpenMethodProps = {
-  webExtensionUSBLedgerAccess?: () => void
+  openLedgerAccessPopup?: () => void
 }
 
-export function FromLedger({ webExtensionUSBLedgerAccess }: SelectOpenMethodProps) {
+export function FromLedger({ openLedgerAccessPopup }: SelectOpenMethodProps) {
   const { t } = useTranslation()
   const [supportsUsbLedger, setSupportsUsbLedger] = React.useState<boolean | undefined>(true)
   const [supportsBleLedger, setSupportsBleLedger] = React.useState<boolean | undefined>(true)
@@ -46,11 +46,11 @@ export function FromLedger({ webExtensionUSBLedgerAccess }: SelectOpenMethodProp
       <Box direction="row-responsive" justify="start" margin={{ top: 'medium' }} gap="medium">
         <div>
           <div>
-            {webExtensionUSBLedgerAccess ? (
+            {openLedgerAccessPopup ? (
               <Button
                 disabled={!supportsUsbLedger}
                 style={{ width: 'fit-content' }}
-                onClick={webExtensionUSBLedgerAccess}
+                onClick={openLedgerAccessPopup}
                 label={t('ledger.extension.grantAccess', 'Grant access to your USB Ledger')}
                 primary
               />

--- a/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
@@ -7,7 +7,6 @@ import { Text } from 'grommet/es6/components/Text'
 import { canAccessBle, canAccessNavigatorUsb } from '../../../../lib/ledger'
 import { useTranslation } from 'react-i18next'
 import { Capacitor } from '@capacitor/core'
-import TransportWebUSB from '@ledgerhq/hw-transport-webusb'
 
 type SelectOpenMethodProps = {
   openLedgerAccessPopup?: () => void
@@ -16,7 +15,6 @@ type SelectOpenMethodProps = {
 export function FromLedger({ openLedgerAccessPopup }: SelectOpenMethodProps) {
   const { t } = useTranslation()
   const [supportsUsbLedger, setSupportsUsbLedger] = React.useState<boolean | undefined>(true)
-  const [hasUsbLedgerAccess, setHasUsbLedgerAccess] = React.useState<boolean | undefined>(undefined)
   const [supportsBleLedger, setSupportsBleLedger] = React.useState<boolean | undefined>(true)
 
   useEffect(() => {
@@ -33,31 +31,6 @@ export function FromLedger({ openLedgerAccessPopup }: SelectOpenMethodProps) {
     getLedgerSupport()
   }, [])
 
-  useEffect(() => {
-    const checkUsbLedgerAccess = async () => {
-      try {
-        // In default ext popup this gets auto-accepted / auto-rejected. In a tab or persistent popup it would
-        // prompt user to select a ledger device. TransportWebUSB.create seems to match requestDevice called in
-        // openLedgerAccessPopup.
-        // If TransportWebUSB.create() is rejected then call openLedgerAccessPopup and requestDevice. When user
-        // confirms the prompt tell them to come back here. TransportWebUSB.create() will resolve.
-        await TransportWebUSB.create()
-        setHasUsbLedgerAccess(true)
-      } catch (error) {
-        setHasUsbLedgerAccess(false)
-      }
-    }
-    if (openLedgerAccessPopup) {
-      checkUsbLedgerAccess()
-    } else {
-      // Assume true in web app. enumerateAccountsFromLedger will call TransportWebUSB.create in next steps
-      // and will prompt user to select a ledger device.
-      setHasUsbLedgerAccess(true)
-    }
-  }, [openLedgerAccessPopup])
-
-  const shouldOpenUsbLedgerAccessPopup = openLedgerAccessPopup && !hasUsbLedgerAccess
-
   return (
     <Box
       round="5px"
@@ -73,7 +46,7 @@ export function FromLedger({ openLedgerAccessPopup }: SelectOpenMethodProps) {
       <Box direction="row-responsive" justify="start" margin={{ top: 'medium' }} gap="medium">
         <div>
           <div>
-            {shouldOpenUsbLedgerAccessPopup ? (
+            {openLedgerAccessPopup ? (
               <Button
                 disabled={!supportsUsbLedger}
                 style={{ width: 'fit-content' }}

--- a/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
@@ -34,15 +34,21 @@ export function FromLedger({ openLedgerAccessPopup }: SelectOpenMethodProps) {
   }, [])
 
   useEffect(() => {
+    const checkUsbLedgerAccess = async () => {
+      try {
+        // In default ext popup this gets auto-accepted / auto-rejected. In a tab or persistent popup it would
+        // prompt user to select a ledger device. TransportWebUSB.create seems to match requestDevice called in
+        // openLedgerAccessPopup.
+        // If TransportWebUSB.create() is rejected then call openLedgerAccessPopup and requestDevice. When user
+        // confirms the prompt tell them to come back here. TransportWebUSB.create() will resolve.
+        await TransportWebUSB.create()
+        setHasUsbLedgerAccess(true)
+      } catch (error) {
+        setHasUsbLedgerAccess(false)
+      }
+    }
     if (openLedgerAccessPopup) {
-      // In default ext popup this gets auto-accepted / auto-rejected. In a tab or persistent popup it would
-      // prompt user to select a ledger device. TransportWebUSB.create seems to match requestDevice called in
-      // openLedgerAccessPopup.
-      // If TransportWebUSB.create() is rejected then call openLedgerAccessPopup and requestDevice. When user
-      // confirms the prompt tell them to come back here. TransportWebUSB.create() will resolve.
-      TransportWebUSB.create()
-        .then(() => setHasUsbLedgerAccess(true))
-        .catch(() => setHasUsbLedgerAccess(false))
+      checkUsbLedgerAccess()
     } else {
       // Assume true in web app. enumerateAccountsFromLedger will call TransportWebUSB.create in next steps
       // and will prompt user to select a ledger device.

--- a/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
+++ b/src/app/pages/OpenWalletPage/Features/FromLedger/index.tsx
@@ -7,6 +7,7 @@ import { Text } from 'grommet/es6/components/Text'
 import { canAccessBle, canAccessNavigatorUsb } from '../../../../lib/ledger'
 import { useTranslation } from 'react-i18next'
 import { Capacitor } from '@capacitor/core'
+import TransportWebUSB from '@ledgerhq/hw-transport-webusb'
 
 type SelectOpenMethodProps = {
   openLedgerAccessPopup?: () => void
@@ -15,6 +16,7 @@ type SelectOpenMethodProps = {
 export function FromLedger({ openLedgerAccessPopup }: SelectOpenMethodProps) {
   const { t } = useTranslation()
   const [supportsUsbLedger, setSupportsUsbLedger] = React.useState<boolean | undefined>(true)
+  const [hasUsbLedgerAccess, setHasUsbLedgerAccess] = React.useState<boolean | undefined>(undefined)
   const [supportsBleLedger, setSupportsBleLedger] = React.useState<boolean | undefined>(true)
 
   useEffect(() => {
@@ -31,6 +33,25 @@ export function FromLedger({ openLedgerAccessPopup }: SelectOpenMethodProps) {
     getLedgerSupport()
   }, [])
 
+  useEffect(() => {
+    if (openLedgerAccessPopup) {
+      // In default ext popup this gets auto-accepted / auto-rejected. In a tab or persistent popup it would
+      // prompt user to select a ledger device. TransportWebUSB.create seems to match requestDevice called in
+      // openLedgerAccessPopup.
+      // If TransportWebUSB.create() is rejected then call openLedgerAccessPopup and requestDevice. When user
+      // confirms the prompt tell them to come back here. TransportWebUSB.create() will resolve.
+      TransportWebUSB.create()
+        .then(() => setHasUsbLedgerAccess(true))
+        .catch(() => setHasUsbLedgerAccess(false))
+    } else {
+      // Assume true in web app. enumerateAccountsFromLedger will call TransportWebUSB.create in next steps
+      // and will prompt user to select a ledger device.
+      setHasUsbLedgerAccess(true)
+    }
+  }, [openLedgerAccessPopup])
+
+  const shouldOpenUsbLedgerAccessPopup = openLedgerAccessPopup && !hasUsbLedgerAccess
+
   return (
     <Box
       round="5px"
@@ -46,7 +67,7 @@ export function FromLedger({ openLedgerAccessPopup }: SelectOpenMethodProps) {
       <Box direction="row-responsive" justify="start" margin={{ top: 'medium' }} gap="medium">
         <div>
           <div>
-            {openLedgerAccessPopup ? (
+            {shouldOpenUsbLedgerAccessPopup ? (
               <Button
                 disabled={!supportsUsbLedger}
                 style={{ width: 'fit-content' }}

--- a/src/app/pages/OpenWalletPage/FromLedgerWebExtension.tsx
+++ b/src/app/pages/OpenWalletPage/FromLedgerWebExtension.tsx
@@ -1,16 +1,14 @@
 import React from 'react'
-import { useHref, useNavigate } from 'react-router-dom'
+import { useHref } from 'react-router-dom'
 import { openLedgerAccessPopup } from 'utils/webextension'
 import { FromLedger } from './Features/FromLedger'
 
 export function FromLedgerWebExtension() {
   const href = useHref('/open-wallet/connect-device')
-  const navigate = useNavigate()
 
   return (
     <FromLedger
       openLedgerAccessPopup={() => {
-        navigate('/open-wallet/ledger/usb')
         openLedgerAccessPopup(href)
       }}
     />

--- a/src/app/pages/OpenWalletPage/FromLedgerWebExtension.tsx
+++ b/src/app/pages/OpenWalletPage/FromLedgerWebExtension.tsx
@@ -3,6 +3,9 @@ import { useHref } from 'react-router-dom'
 import { openLedgerAccessPopup } from 'utils/webextension'
 import { FromLedger } from './Features/FromLedger'
 import TransportWebUSB from '@ledgerhq/hw-transport-webusb'
+import { MessageTypes, MessageType } from '../../../utils/constants'
+
+const chrome = (window as any).chrome
 
 export function FromLedgerWebExtension() {
   const href = useHref('/open-wallet/connect-device')
@@ -23,6 +26,17 @@ export function FromLedgerWebExtension() {
       }
     }
     checkUsbLedgerAccess()
+
+    const handleMessage = (message: { type: MessageType }) => {
+      if (message.type === MessageTypes.USB_LEDGER_PERMISSION_GRANTED) {
+        setHasUsbLedgerAccess(true)
+      }
+    }
+    chrome.runtime.onMessage.addListener(handleMessage)
+
+    return () => {
+      chrome.runtime.onMessage.removeListener(handleMessage)
+    }
   }, [])
 
   return (

--- a/src/app/pages/OpenWalletPage/FromLedgerWebExtension.tsx
+++ b/src/app/pages/OpenWalletPage/FromLedgerWebExtension.tsx
@@ -9,7 +9,7 @@ export function FromLedgerWebExtension() {
 
   return (
     <FromLedger
-      webExtensionUSBLedgerAccess={() => {
+      openLedgerAccessPopup={() => {
         navigate('/open-wallet/ledger/usb')
         openLedgerAccessPopup(href)
       }}

--- a/src/app/pages/OpenWalletPage/FromLedgerWebExtension.tsx
+++ b/src/app/pages/OpenWalletPage/FromLedgerWebExtension.tsx
@@ -1,16 +1,39 @@
-import React from 'react'
+import { useEffect, useState } from 'react'
 import { useHref } from 'react-router-dom'
 import { openLedgerAccessPopup } from 'utils/webextension'
 import { FromLedger } from './Features/FromLedger'
+import TransportWebUSB from '@ledgerhq/hw-transport-webusb'
 
 export function FromLedgerWebExtension() {
   const href = useHref('/open-wallet/connect-device')
+  const [hasUsbLedgerAccess, setHasUsbLedgerAccess] = useState<boolean | undefined>(undefined)
+
+  useEffect(() => {
+    const checkUsbLedgerAccess = async () => {
+      try {
+        // In default ext popup this gets auto-accepted / auto-rejected. In a tab or persistent popup it would
+        // prompt user to select a ledger device. TransportWebUSB.create seems to match requestDevice called in
+        // openLedgerAccessPopup.
+        // If TransportWebUSB.create() is rejected then call openLedgerAccessPopup and requestDevice. When user
+        // confirms the prompt tell them to come back here. TransportWebUSB.create() will resolve.
+        await TransportWebUSB.create()
+        setHasUsbLedgerAccess(true)
+      } catch (error) {
+        setHasUsbLedgerAccess(false)
+      }
+    }
+    checkUsbLedgerAccess()
+  }, [])
 
   return (
     <FromLedger
-      openLedgerAccessPopup={() => {
-        openLedgerAccessPopup(href)
-      }}
+      openLedgerAccessPopup={
+        hasUsbLedgerAccess === false
+          ? () => {
+              openLedgerAccessPopup(href)
+            }
+          : undefined
+      }
     />
   )
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,5 @@
+export const MessageTypes = {
+  USB_LEDGER_PERMISSION_GRANTED: 'usb-ledger-permission-granted',
+} as const
+
+export type MessageType = (typeof MessageTypes)[keyof typeof MessageTypes]


### PR DESCRIPTION
Extracted from https://github.com/oasisprotocol/wallet/pull/2084

Related to https://github.com/oasisprotocol/wallet/pull/2084#discussion_r1830380814

Previous flow:
- '#/open-wallet/ledger' has "Grant access to your Ledger" button
- it opens '#/open-wallet/connect-device' in permanent popup as well as navigates self-closing popup to '#/open-wallet/ledger/usb' (both stay open)
- connect-device popup has "Connect Ledger device" button that requests usb permission, selects device, and triggers listing accounts in redux. That is synced into self-closing popup
- when done in connect-device popup, user tries to continue in self-closing popup, but it closes
- when reopening, and navigating to import from ledger again, it skips some steps because it still has ledger listed accounts in redux
- some user actions will clear that store. Then if user navigates to import from ledger again, it will show "Grant access to your Ledger" and popup again

New flow:
- '#/open-wallet/ledger' has "Grant access to your Ledger" button if it has not been granted permission before
- it opens '#/open-wallet/connect-device' in permanent popup
- connect-device popup has "Connect Ledger device" button that requests usb permission, and selects device. This already gives necessary permissions to self-closing popup
- when done in connect-device popup, user tries to continue in self-closing popup, but it closes
- when reopening, and navigating to import from ledger again, it shows "USB Ledger" button this time (same every time user comes back with already granted permissions)

(I don't have a test ledger device right now. Please check if some of these notes are incorrect)