### PR TITLE
android: Bump min SDK version

### DIFF
--- a/.changelog/2110.bugfix.md
+++ b/.changelog/2110.bugfix.md
@@ -1,0 +1,1 @@
+android: Bump min SDK version

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,5 +1,5 @@
 ext {
-    minSdkVersion = 22
+    minSdkVersion = 30
     compileSdkVersion = 34
     targetSdkVersion = 34
     androidxActivityVersion = '1.8.0'


### PR DESCRIPTION
## Description

Mitigates StrandHogg attack, due to vulnerability on Android 10 or lower.

## Solution

https://developer.android.com/privacy-and-security/risks/strandhogg#mitigations