### PR TITLE
Disable E2E test for transak embedded in extension

### DIFF
--- a/.changelog/2132.trivial.md
+++ b/.changelog/2132.trivial.md
@@ -1,0 +1,1 @@
+Disable E2E test for transak embedded in extension

--- a/playwright/tests/extension.spec.ts
+++ b/playwright/tests/extension.spec.ts
@@ -89,6 +89,7 @@ test.describe('The extension popup should load', () => {
     {
       const page = await context.newPage()
       await page.goto(`${extensionPopupURL}/e2e`)
+      expect(page.getByRole('button', { name: 'Trigger fatal saga error' })).toBeVisible() // Was built with REACT_APP_E2E_TEST=1?
       await page.getByRole('button', { name: 'Trigger fatal saga error' }).click()
       await expect(page.getByTestId('fatalerror-stacktrace')).toBeVisible()
 

--- a/playwright/tests/extension.spec.ts
+++ b/playwright/tests/extension.spec.ts
@@ -46,7 +46,8 @@ test.describe('The extension popup should load', () => {
    * Extension should be able to show embedded Transak, but we currently link to
    * it instead. Ext popup is too small and loses all progress when it closes.
    */
-  test('should allow embedded Transak widget in large popups', async ({ page, extensionPopupURL }) => {
+  test('Transak can not be embedded in extension', async ({ page, extensionPopupURL }) => {
+    test.fail()
     await page.setViewportSize({ width: 1280, height: 720 })
 
     /* TODO: reenable when transak throws only a few errors


### PR DESCRIPTION
Looks like extensions don't send origin/referrer header when loading iframe and transak now responds with `Referrer-Policy: same-origin; X-Frame-Options: sameorigin;`

Luckily our extension does not embed transak, but opens it in a new tab. Mobile app too, except maybe on tablets. Not sure if iframe would load in a mobile app context