### PR TITLE
Fallback to transak button if embedded doesn't initialize after 5sec

### DIFF
--- a/.changelog/2154.bugfix.md
+++ b/.changelog/2154.bugfix.md
@@ -1,0 +1,1 @@
+Fallback to transak button if embedded doesn't initialize after 5sec

--- a/playwright/tests/fiat.spec.ts
+++ b/playwright/tests/fiat.spec.ts
@@ -54,7 +54,7 @@ test.describe('Fiat on-ramp', () => {
     await expectNoErrorsInConsole(page)
     await setup(page)
     await page.route('https://*.transak.com/?*', route =>
-      route.fulfill({ status: 301, headers: { Location: 'https://global-stg.transak.com/' } }),
+      route.fulfill({ status: 302, headers: { Location: 'https://global-stg.transak.com/' } }),
     )
 
     await page
@@ -70,7 +70,7 @@ test.describe('Fiat on-ramp', () => {
     await expectNoErrorsInConsole(page)
     await setup(page)
     await page.route('https://*.transak.com/*', route =>
-      route.fulfill({ status: 301, headers: { Location: 'https://phishing-transak.com/' } }),
+      route.fulfill({ status: 302, headers: { Location: 'https://phishing-transak.com/' } }),
     )
     await page.route('https://phishing-transak.com/', route => route.fulfill({ body: `phishing` }))
 


### PR DESCRIPTION
Related to https://github.com/oasisprotocol/wallet/pull/2132

Extensions don't send origin/referrer header when loading iframe and transak now
responds with `Referrer-Policy: same-origin; X-Frame-Options: sameorigin;`.

We embed transak based on window size, so transak could get embedded and fail if
user opens the extension in a large tab. This mitigates a failure in 5 seconds.

![Peek 2025-03-24 20-43](https://github.com/user-attachments/assets/2a77f16b-efb0-4c8b-99fa-a6b1a488e305)
