### PR TITLE
Fix flaky test - sync 44 accounts in 10 tabs

### DIFF
--- a/.changelog/2169.trivial.md
+++ b/.changelog/2169.trivial.md
@@ -1,0 +1,1 @@
+Fix flaky test - sync 44 accounts in 10 tabs

--- a/playwright/tests/syncTabs.spec.ts
+++ b/playwright/tests/syncTabs.spec.ts
@@ -287,7 +287,7 @@ test.describe('syncTabs', () => {
     })
     await test.step('Test syncing actions to 10 tabs', async () => {
       await page.getByTestId('network-selector').click()
-      await page.getByRole('menuitem', { name: 'Mainnet' }).click()
+      await page.getByRole('menuitem', { name: 'Mainnet' }).click({ timeout: 10_000 })
       for (const tab of context.pages()) {
         await expect(tab.getByTestId('network-selector')).toHaveText('Mainnet')
       }


### PR DESCRIPTION
This test usually passes after two automatic retries. And very rarely it fails all three repeats

Tried to reproduce here:
https://github.com/oasisprotocol/wallet/actions/runs/14473819140/job/40594465703 0/3 failed
https://github.com/oasisprotocol/wallet/actions/runs/14473819140/job/40597292495 7/9 failed

After
https://github.com/oasisprotocol/wallet/actions/runs/14473822355/job/40594471812 0/3 failed
https://github.com/oasisprotocol/wallet/actions/runs/14473822355/job/40597299796 0/3 failed
https://github.com/oasisprotocol/wallet/actions/runs/14473822355/job/40598095792 0/3 failed