### PR TITLE
Set CSS color-scheme to match grommet dark theme

### DIFF
--- a/.changelog/2170.internal.md
+++ b/.changelog/2170.internal.md
@@ -1,0 +1,1 @@
+Set CSS color-scheme to match grommet dark theme

--- a/src/styles/theme/ThemeProvider.tsx
+++ b/src/styles/theme/ThemeProvider.tsx
@@ -7,7 +7,7 @@ import { useSelector } from 'react-redux'
 
 import { selectTheme } from './slice/selectors'
 import { dataTableTheme } from './dataTableTheme'
-import { css } from 'styled-components'
+import { createGlobalStyle, css } from 'styled-components'
 import { getTargetTheme } from './utils'
 import { getInitialState as getInitialThemeState } from './slice'
 
@@ -383,12 +383,20 @@ const grommetCustomTheme: ThemeType = {
     },
   },
 }
+
+const GlobalStyle = createGlobalStyle`
+  :root {
+    color-scheme: ${({ theme }) => ((theme as any).dark ? 'dark' : 'light')};
+  }
+`
+
 export const ThemeProvider = (props: { children: React.ReactNode }) => {
   const theme = deepMerge(grommet, grommetCustomTheme)
   const mode = useSelector(selectTheme)
 
   return (
     <Grommet theme={theme} themeMode={getTargetTheme(mode)} style={{ minHeight: '100dvh' }}>
+      <GlobalStyle />
       {React.Children.only(props.children)}
     </Grommet>
   )


### PR DESCRIPTION
- improves scrollbar color
- supports `@media (prefers-color-scheme: dark)` in svg icons

| Before | After |
| --- | --- |
| ![before1](https://github.com/user-attachments/assets/31d90638-a41b-4f54-a4c6-a41f469a5e4b) | ![after1](https://github.com/user-attachments/assets/d8c5c069-4821-4b55-9d45-c75e8821f725) |
| ![before4](https://github.com/user-attachments/assets/75ece158-a22c-45b0-8639-39d0a919621f) | ![after4](https://github.com/user-attachments/assets/b9a89d9a-ab69-46f0-97d1-00e9de6efdf4) |
| ![before3](https://github.com/user-attachments/assets/e502ac13-9849-4797-aa42-5421afaf34ad) | ![after3](https://github.com/user-attachments/assets/5e3fb8d2-b832-454d-a518-9ebc1dd34872) |
| ![before2](https://github.com/user-attachments/assets/1894a021-950a-458f-b2be-f43c248afd63) | ![after2](https://github.com/user-attachments/assets/5b6ecb9d-fe27-48cf-aa09-d2d3f75ad706) |



