### PR TITLE
Fix screenshots CI

### DIFF
--- a/.changelog/2186.internal.md
+++ b/.changelog/2186.internal.md
@@ -1,0 +1,1 @@
+Fix screenshots CI

--- a/playwright/screenshots/chrome-webstore-screenshots.spec.ts
+++ b/playwright/screenshots/chrome-webstore-screenshots.spec.ts
@@ -110,7 +110,7 @@ test('make screenshots for Chrome Web Store', async ({ page }) => {
   })
 
   await frame.getByRole('button', { name: 'Deposit to ParaTime' }).click()
-  await frame.getByRole('textbox', { name: 'Select a ParaTime' }).click()
+  await frame.getByRole('button', { name: 'Select a ParaTime' }).click()
   await page.screenshot({
     path: './screenshots/extension-store-6.png',
     style: screenshotCss,


### PR DESCRIPTION
Screenshots CI was still broken. https://github.com/oasisprotocol/wallet/actions/workflows/update-screenshots.yml

All causes since https://github.com/oasisprotocol/wallet/pull/2174:
- images were broken (https://github.com/oasisprotocol/wallet/pull/2182)
- defaultProps in our app showed warning overlays covering buttons clicked in screenshot script (https://github.com/oasisprotocol/wallet/pull/2181)
- defaultProps in previous grommet (https://github.com/oasisprotocol/wallet/pull/2181)
- mocking requests and debug prints showed warning overlays (https://github.com/oasisprotocol/wallet/pull/2184)
- "Select a ParaTime" isn't a textbox in new grommet (this PR)